### PR TITLE
Updated prints to python 3 syntax in euler-hamiltonian page

### DIFF
--- a/src/s_graphs_eulerham.ptx
+++ b/src/s_graphs_eulerham.ptx
@@ -24,7 +24,7 @@ edges = 28
 g = graphs.RandomGNM(vertices,edges)
 while (not g.is_eulerian() or not g.is_connected()):
     g = graphs.RandomGNM(vertices,edges)
-print g.degree_sequence()
+print(g.degree_sequence())
 g.show()
         </input>
     </sage>
@@ -39,7 +39,7 @@ edges = 25
 g = graphs.RandomGNM(vertices,edges)
 while (g.is_eulerian() or not g.is_connected()):
     g = graphs.RandomGNM(vertices,edges)
-print g.degree_sequence()
+print(g.degree_sequence())
 g.show()
         </input>
     </sage>


### PR DESCRIPTION
Updated prints to python 3 syntax to fix a sage error in the euler-hamiltonian page of the textbook (section 5.3)