### PR TITLE
docs: link to hosted html

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains the source code for the body of the text and all figure files for the text Applied Combinatorics by Mitchel T. Keller and William T. Trotter. This text is copyright 2006-2020 by Mitchel T. Keller and William T. Trotter. Please see LICENSE.md for license details.
 
+You can read a hosted HTML version of the book at [appliedcombinatorics.org](https://appliedcombinatorics.org/book/app-comb.html).
+
 As of May 2022, the PreTeXt CLI is the offical way to build the HTML for Applied Combinatorics. After installing the CLI, run `pretext build html`. You can then view your local copy of the HTML with `pretext view html`, which will give you a local URL to open.
 
 The LaTeX build is considered frozen until a full new edition is released.


### PR DESCRIPTION
Add link to the hosted HTML edition of Applied Combinatorics in the README
